### PR TITLE
Use system font for sidebar wordmark

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,9 +68,6 @@
         "articleSection": "Research"
     }
     </script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=IM+Fell+English+SC&display=swap" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <style>
         :root {
@@ -128,13 +125,11 @@
 
         .sidebar-wordmark {
             display: block;
-            font-family: 'IM Fell English SC', 'Cormorant SC', Georgia, serif;
-            font-size: 26px;
-            font-weight: 400;
+            font-size: 18px;
+            font-weight: 700;
             color: var(--text);
-            letter-spacing: 0.5px;
-            line-height: 1;
-            white-space: nowrap;
+            letter-spacing: -0.2px;
+            line-height: 1.2;
         }
 
         .sidebar-title {


### PR DESCRIPTION
## Summary

Removes the Google Font (`IM Fell English SC`) used for the "Presidio Bitcoin" wordmark in the sidebar, and replaces it with the same system font stack already used elsewhere on the page.

## Why

The previous font was a rough free-Google-Font approximation of the Presidio Bitcoin brand mark, but it is not the actual brand font. Rather than ship something that almost-but-not-quite matches the brand, this falls back to neutral typography. The wordmark stays visually distinct via weight (bold), size (18px), and slight negative letter-spacing.

Side benefits: one fewer external network request on page load (the Google Fonts `<link>` and two `preconnect` lines are removed), and no third-party font dependency.

## Diff scope

`index.html` only. 4 lines added, 9 removed. No content, deploy, or workflow changes.